### PR TITLE
CORE-832: Add `cryptoWalletCreateTransferMultiple()`

### DIFF
--- a/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferMultiSpec.java
+++ b/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferMultiSpec.java
@@ -1,0 +1,44 @@
+package com.breadwallet.corenative.crypto;
+
+import com.sun.jna.Structure;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class BRCryptoTransferMultiSpec extends Structure {
+    public BRCryptoAddress target;
+    public BRCryptoAmount  amount;
+
+    public BRCryptoTransferMultiSpec() {
+        super();
+    }
+
+    public BRCryptoTransferMultiSpec(BRCryptoAddress target, BRCryptoAmount amount) {
+        super();
+        this.target = target;
+        this.amount = amount;
+    }
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return Arrays.asList(
+                "target",
+                "amount"
+        );
+    }
+
+    public BRCryptoTransferMultiSpec.ByValue toByValue() {
+        BRCryptoTransferMultiSpec.ByValue other = new BRCryptoTransferMultiSpec.ByValue();
+
+        other.target = this.target;
+        other.amount = this.amount;
+
+        return other;
+    }
+
+    public static class ByReference extends BRCryptoTransferMultiSpec implements Structure.ByReference {
+    }
+
+    public static class ByValue extends BRCryptoTransferMultiSpec implements Structure.ByValue {
+    }
+}

--- a/corecrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
+++ b/corecrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
@@ -15,6 +15,7 @@ import com.breadwallet.corenative.crypto.BRCryptoNetworkFee;
 import com.breadwallet.corenative.crypto.BRCryptoPaymentProtocolRequest;
 import com.breadwallet.corenative.crypto.BRCryptoTransfer;
 import com.breadwallet.corenative.crypto.BRCryptoTransferAttribute;
+import com.breadwallet.corenative.crypto.BRCryptoTransferMultiSpec;
 import com.breadwallet.corenative.crypto.BRCryptoWallet;
 import com.breadwallet.corenative.crypto.BRCryptoWalletManager;
 import com.breadwallet.corenative.crypto.BRCryptoWalletSweeper;
@@ -108,6 +109,23 @@ final class Wallet implements com.breadwallet.crypto.Wallet {
             }
 
         return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes).transform(t -> Transfer.create(t, this));
+    }
+
+    @Override
+    public Optional<Transfer> createTransferMultiple(List<TransferPart> parts,
+                                                     com.breadwallet.crypto.TransferFeeBasis estimatedFeeBasis) {
+        BRCryptoFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
+
+
+        List<BRCryptoTransferMultiSpec> coreParts = new ArrayList<>();
+        if (null != parts) {
+            for (Wallet.TransferPart part : parts) {
+                coreParts.add(new BRCryptoTransferMultiSpec(
+                        Address.from(part.target).getCoreBRCryptoAddress(),
+                        Amount.from(part.amount).getCoreBRCryptoAmount()));
+            }
+        }
+        return core.createTransferMultiple(coreParts, coreFeeBasis).transform(t -> Transfer.create(t, this));
     }
 
     /* package */

--- a/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -9,6 +9,7 @@ package com.breadwallet.corenative;
 
 import com.breadwallet.corenative.crypto.BRCryptoNetworkFee;
 import com.breadwallet.corenative.crypto.BRCryptoTransferAttribute;
+import com.breadwallet.corenative.crypto.BRCryptoTransferMultiSpec;
 import com.breadwallet.corenative.utility.SizeT;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
@@ -40,6 +41,11 @@ public final class CryptoLibraryIndirect {
         return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, countOfAttributes, attributes, validates);
     }
 
+    public static Pointer cryptoWalletCreateTransferMultiple(Pointer wallet, SizeT specsCount, BRCryptoTransferMultiSpec[] specs, Pointer feeBasis) {
+        specs = specs.length == 0 ? null : specs;
+        return INSTANCE.cryptoWalletCreateTransferMultiple(wallet, specsCount, specs, feeBasis);
+    }
+
     public static void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState, int status,
                                                      String hash, String uids, String sourceAddr, String targetAddr,
                                                      String amount, String currency, String fee,
@@ -63,7 +69,10 @@ public final class CryptoLibraryIndirect {
 
         // crypto/BRCryptoWallet.h
         Pointer cryptoWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, BRCryptoTransferAttribute[] attributes);
+
         int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, BRCryptoTransferAttribute[] attributes, IntByReference validates);
+
+        Pointer cryptoWalletCreateTransferMultiple(Pointer wallet, SizeT specsCount, BRCryptoTransferMultiSpec[] specs, Pointer feeBasis);
 
         void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState, int status,
                                            String hash, String uids, String sourceAddr, String targetAddr,

--- a/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWallet.java
+++ b/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWallet.java
@@ -217,6 +217,24 @@ public class BRCryptoWallet extends PointerType {
         ).transform(BRCryptoTransfer::new);
     }
 
+    public Optional<BRCryptoTransfer> createTransferMultiple(List<BRCryptoTransferMultiSpec> specs,
+                                                             BRCryptoFeeBasis estimatedFeeBasis) {
+        Pointer thisPtr = this.getPointer();
+
+        int specsCount = specs.size();
+        BRCryptoTransferMultiSpec[] specsRef = new BRCryptoTransferMultiSpec[specsCount];
+        for (int i = 0; i < specsCount; i++) specsRef[i] = specs.get(i);
+
+        return Optional.fromNullable(
+                CryptoLibraryIndirect.cryptoWalletCreateTransferMultiple(
+                        thisPtr,
+                        new SizeT(specsCount),
+                        specsRef,
+                        estimatedFeeBasis.getPointer()
+                )
+        ).transform(BRCryptoTransfer::new);
+    }
+
     public Optional<BRCryptoTransfer> createTransferForWalletSweep(BRCryptoWalletSweeper sweeper, BRCryptoFeeBasis estimatedFeeBasis) {
         Pointer thisPtr = this.getPointer();
 

--- a/crypto/src/main/java/com/breadwallet/crypto/Wallet.java
+++ b/crypto/src/main/java/com/breadwallet/crypto/Wallet.java
@@ -31,6 +31,18 @@ public interface Wallet {
 
     Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes);
 
+    class TransferPart {
+        public Address target;
+        public Amount  amount;
+
+        public TransferPart (Address target, Amount amount) {
+            this.target = target;
+            this.amount = amount;
+        }
+    }
+
+    Optional<? extends Transfer> createTransferMultiple (List<TransferPart> parts, TransferFeeBasis estimatedFeeBasis);
+
     /**
      * Estimate the fee for a transfer with `amount` from `wallet`.  If provided use the `feeBasis`
      * otherwise use the wallet's `defaultFeeBasis`


### PR DESCRIPTION
Seeking suggestions.  Created BRCryptoTransferMultiSpec in Java as a struct to model the C structure.  But then in the Wallet interface introduced TransferPart.  Perhaps better to introduce TransferMultiSpec in the top-level interface which is then implemented with some BRCryptoTransferMultiSpec.

Note: Not a fan of the word 'MultiSpec' .